### PR TITLE
Add make-file-error, describe peek and port-position interactions

### DIFF
--- a/srfi-181-192/README.md
+++ b/srfi-181-192/README.md
@@ -32,15 +32,25 @@ A sample implementation for Gauche is also provided, using its own
 custom port layer `(gauche.vport)`.  However, Gauche's `vport` lacks
 some functionality to fully support SRFI 181.
 
-Note on `peek-char` / `peek-u8`
----------------------------
 
-Draft #5 omitted `peek-char`/`u8` to avoid complications of port position
-tracking.  However, one-character look-ahead is needed to implement `read`
-and `read-line`, so at least the custom textual port needs to have some
-sort of peek functionality internally, even if it doesn't export the feature.
+Note on `peek-char`/`peek-u8`
+-------------------------
 
-For now, I keep them in the library.
+Implementers need to be aware that `peek-char` / `peek-u8` requires buffering
+in the custom port, so the port-position (where the next read or write
+operation on the port occurs) and what `get-position` callback returns (where
+the next `read!` callback reads from, or next `write!` callback writes to)
+may differ.  The test code includes testing such subtleties.
+
+The reference implementation adopts peek opertaions by (1) calling `get-position`
+callback to remember the current underlying position, (2) calling `read!`
+callback to fetch the data and buffer it, then (3) returning the fetched
+data.  When `port-position` is called then, it returns the cached
+position, instead of delegating it to `get-position` callback.
+
+There may be different ways to implement it.  Just keep in mind that
+letting `port-position` always call `get-position` won't work.
+
 
 
 Note on transcoded port implementation

--- a/srfi-181-192/README.md
+++ b/srfi-181-192/README.md
@@ -18,7 +18,8 @@ were another kind of port:
                     read-string read-u8 peek-u8 u8-ready?
                     read-bytevector read-bytevector!
                     write-char write-string write-u8
-                    write-bytevector flush-output-port)
+                    write-bytevector flush-output-port
+                    file-error?)
             (srfi 181 adapter)   ;; includes read and write
             (srfi 181))
 

--- a/srfi-181-192/srfi/181.gauche.scm
+++ b/srfi-181-192/srfi/181.gauche.scm
@@ -101,3 +101,11 @@
     :seek (make-seeker get-position set-position!)
     :flush (^[] (and flush (flush)))
     :close close))
+
+(define (make-file-error . objs)
+  ;; Up to 0.9.9, Gauche uses ad-hoc way to determine file-error--
+  ;; that is, a <system-error> with certain errnos is a file error. 
+  ;; It is impossible to translate arbitrary objs into meaningful 
+  ;; <system-error>.  This is just a crude emulation.
+  (condition
+   (<system-error> (errno ENXIO) (message (write-to-string objs)))))

--- a/srfi-181-192/srfi/181.sld
+++ b/srfi-181-192/srfi/181.sld
@@ -4,6 +4,7 @@
           make-custom-binary-output-port
           make-custom-textual-output-port
           make-custom-binary-input/output-port
+          make-file-error
 
           make-codec latin-1-codec utf-8-codec utf-16-codec
           native-eol-style

--- a/srfi-181-192/srfi/181/adapter.scm
+++ b/srfi-181-192/srfi/181/adapter.scm
@@ -105,6 +105,10 @@
            ((input-port? port) (u8-ready? port))
            (else (error "input port expected, got" port))))))
 
+(define (cp:file-error? obj)
+  (or (file-error? obj)
+      (custom-port-file-error? obj)))
+
 ;;;
 ;;; Derived operations
 ;;;

--- a/srfi-181-192/srfi/181/adapter.sld
+++ b/srfi-181-192/srfi/181/adapter.sld
@@ -38,6 +38,7 @@
           (rename cp:write-u8 write-u8)
           (rename cp:write-bytevector write-bytevector)
           (rename cp:flush-output-port flush-output-port)
+          (rename cp:file-error? file-error?)
           )
   (include "adapter.scm")
   )

--- a/srfi-181-192/srfi/181/generic.scm
+++ b/srfi-181-192/srfi/181/generic.scm
@@ -32,7 +32,19 @@
   (closer custom-port-closer)
   (flusher custom-port-flusher))
 
+(define-record-type custom-port-file-error
+  (%make-custom-port-file-error objs)
+  custom-port-file-error?
+  (objs custom-port-file-error-objs))
+
 (define (boolean x) (not (not x)))
+
+;;
+;; Custom port internal interface
+;;
+;; (srfi 181 adapter) dispatches R7RS file operations on custom ports to
+;; these internal APIs.
+;;
 
 (define (custom-port-has-port-position? port)
   (assume (custom-port? port))
@@ -152,6 +164,10 @@
   (let ((flusher (custom-port-flusher port)))
     (and flusher (flusher))))
 
+;;
+;; SRFI-181 public API
+;;
+
 (define (make-custom-binary-input-port id read!
                                        get-position set-position!
                                        close)
@@ -204,3 +220,6 @@
                        set-position!
                        close
                        flush)))
+
+(define (make-file-error . objs)
+  (%make-custom-port-file-error objs))

--- a/srfi-181-192/srfi/181/generic.sld
+++ b/srfi-181-192/srfi/181/generic.sld
@@ -23,10 +23,12 @@
           custom-port-write-char
           custom-port-close
           custom-port-flush
+          custom-port-file-error?
 
           make-custom-binary-input-port
           make-custom-textual-input-port
           make-custom-binary-output-port
           make-custom-textual-output-port
-          make-custom-binary-input/output-port)
+          make-custom-binary-input/output-port
+          make-file-error)
   (include "generic.scm"))

--- a/srfi-181-192/srfi/181/transcoder.sld
+++ b/srfi-181-192/srfi/181/transcoder.sld
@@ -10,7 +10,7 @@
                   read-string read-u8 peek-u8 u8-ready?
                   read-bytevector read-bytevector!
                   write-char write-string write-u8
-                  write-bytevector flush-output-port)
+                  write-bytevector flush-output-port file-error?)
           (scheme char)
           (scheme list)
           (srfi 181 adapter)

--- a/srfi-181-192/test.scm
+++ b/srfi-181-192/test.scm
@@ -15,7 +15,7 @@
                          read-string read-u8 peek-u8 u8-ready?
                          read-bytevector read-bytevector!
                          write-char write-string write-u8
-                         write-bytevector flush-output-port)
+                         write-bytevector flush-output-port file-error?)
                  (srfi 1)
                  (srfi 130)
                  (except (chibi test) test-equal)
@@ -388,6 +388,10 @@
  )
 
 )) ; cond expand
+
+(test-group
+ "file-error"
+ (test-assert "file-error" (file-error? (make-file-error "bad"))))
 
 (test-group
  "high-level i/o"


### PR DESCRIPTION
Add `make-file-error` according to the newer draft.  `(srfi 181 adapter)` overrides `file-error?` to handle our own file errors.

In README of the reference implementation, update the note on `peek-char`/`peek-u8` to describe what `port-position` returns may differ from what `get-position` returns.
