### PR TITLE
Fix typo and change "draft" to "final"

### DIFF
--- a/srfi-192.html
+++ b/srfi-192.html
@@ -16,7 +16,7 @@ Shiro Kawai (implementation; requires a hook)</p>
 
   <h2>Status</h2>
 
-  <p>This SRFI is currently in <em>draft</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+192+at+srfi+dotschemers+dot+org">srfi-192@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-192">archive</a>.</p>
+  <p>This SRFI is currently in <em>final</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+192+at+srfi+dotschemers+dot+org">srfi-192@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-192">archive</a>.</p>
   <ul>
     <li>Received: 2020-04-14</li>
     <li>Draft #1 published: 2020-04-14</li>
@@ -117,7 +117,7 @@ an error satisfying <code>i/o-invalid-position-error?</code> is signaled.
 
 <code id="make-i/o-invalid-position-error">(make-i/o-invalid-position-error<i> pos</i>)</code>
 <p>Returns a condition object which satisfies
-<code>i/o-invalid-position-error</code>.  The <i>pos</i> argument
+<code>i/o-invalid-position-error?</code>.  The <i>pos</i> argument
 represents a position passed to <code>set-position!</code>.</p>
 <code id="i/o-invalid-position-error?">(i/o-invalid-position-error?<i> obj</i>)</code>
 <p>Returns <code>#t</code> if <i>obj</i> is an object created by


### PR DESCRIPTION
Not sure if this is the right way to do this (do you prefer an email to the mailing list?)

No big deal, only two tiny changes:

* changes the word 'draft' to 'final', since the SRFi has been finalized
* add `?` to `i/o-invalid-position-error?`