### PR TITLE
Fix invalid library name

### DIFF
--- a/srfi-181-192/examples/vector-ports.scm
+++ b/srfi-181-192/examples/vector-ports.scm
@@ -92,7 +92,7 @@
 (define *output-vectors* (cons #f '()))
 
 (cond-expand
- ((library (scheme ephemeronxx))
+ ((library (scheme ephemeron))
   (begin 
     (define weak-cons make-ephemeron)
     (define (weak-find key alis)


### PR DESCRIPTION
I changed it temporarily to test the other clause of cond-expand, and
forgot to edit it back before committing.